### PR TITLE
Generate a UML Diagram from Migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,23 @@ php artisan plant:controllers
 ```
 This create the controller in your app/controllers folder, for this you should create in classes using controller namespace in your class diagram. If controller exists, it only add new methods.
 
+### Generate a UML Diagram from Migrations
+Simply execute the following command in your terminal:
+```
+php artisan plant:generate
+```
+This will search for all migrations in your Laravel project, analyze the table and column definitions, and generate a file named database_diagram.puml in the root of your project.
+
+New Feature:
+The new functionality allows automatically generating UML diagrams from database migrations. This includes mapping the attributes and relationships of the tables defined in the migrations. This feature is especially useful for quickly understanding the database structure and facilitating project documentation, providing a clear and visually understandable overview of the database architecture.
+
 # If you are using Visual Studio Code
 Exist a extension for plantUML please Launch VS Code Quick Open (Ctrl + P) and type `ext install plantuml`, then install PlantUml ext. if you are using the local file plantuml.jar please you must have installed Java and Graphviz, for generate preview screen in VS. for example in Mac `brew install graphviz`.
 
+
 # Testing
 Exist a couple of PHpUnit components, for using in package vendor/bin/phpunit tests/CreateControllersTest.php 
+
 
 # Next
 In next versions the package will generate another layers of your code using the class or package diagram from PlantUML.

--- a/src/Commands/GenerateUmlFromMigrations.php
+++ b/src/Commands/GenerateUmlFromMigrations.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Brianpando\Plantumlgen\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Str;
+
+class GenerateUmlFromMigrations extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'plant:generate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate UML from database migrations';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $migrationFiles = $this->getMigrationFiles();
+        $tables = [];
+        foreach ($migrationFiles as $migrationFile) {
+            $table = new Table();
+            $table->name = $this->getTableNameFromMigration($migrationFile);
+            list($columns, $foreignKeys) = $this->getDetailsFromMigration($migrationFile);
+            $table->columns = $columns;
+            $table->foreignKeys = $foreignKeys;
+            //add objet to tables
+            $tables[] = $table;
+        }
+        $umlContent = $this->buildUmlFromTables($tables);
+
+        // save diagram 
+        $umlFilePath = base_path('database_diagram.puml');
+        File::put($umlFilePath, $umlContent);
+
+        $this->info('UML diagram generated successfully.');
+    }
+
+    /**
+     * Get all migration files.
+     *
+     * @return array
+     */
+    protected function getMigrationFiles()
+    {
+        return File::glob(database_path('migrations/*.php'));
+    }
+
+    /**
+     * Get the table name from a migration file.
+     *
+     * @param string $migrationFile
+     * @return string
+     */
+    protected function getTableNameFromMigration($migrationFile)
+    {
+
+        $fileName = pathinfo($migrationFile, PATHINFO_FILENAME);
+
+        //Extract class name from migration file
+        preg_match('/create_(\w+)_table/', $fileName, $matches);
+
+        // get mateches
+        $className = $matches[1] ?? null;
+
+        // convert class name to camel case
+        return Str::studly($className);
+    }
+
+    /**
+     * Get the columns and foreign keys from a migration file.
+     *
+     * @param string $migrationFile
+     * @return array
+     */
+    /**
+     * Get the columns and foreign keys from a migration file.
+     *
+     * @param string $migrationFile
+     * @return array
+     */
+    protected function getDetailsFromMigration($migrationFile)
+    {
+
+        $migrationContent = file_get_contents($migrationFile);
+
+
+        $upContent = $this->extractUpMethodContent($migrationContent);
+
+        $columns = $this->extractColumnsFromUpMethod($upContent);
+        $foreignKeys = $this->extractForeignKeysFromColumns($columns);
+
+        return [$columns, $foreignKeys];
+    }
+
+    protected function extractUpMethodContent($migrationContent)
+    {
+        preg_match('/Schema::create\(\'(.+?)\',\s*function\s*\(Blueprint\s*\$table\)\s*{(.+?)\}\);/s', $migrationContent, $matches);
+        if (isset($matches[2])) {
+            return $matches[2];
+        }
+        return '';
+    }
+
+    protected function extractColumnsFromUpMethod($upContent)
+    {
+        $columns = [];
+        preg_match_all('/\$table->([^\s\(]+)\([\'"]([^\'"]+)[\'"](?:,|\))/m', $upContent, $columnMatches, PREG_SET_ORDER);
+        foreach ($columnMatches as $columnMatch) {
+            $columnName = $columnMatch[2];
+            $columnType = $columnMatch[1];
+            $columns[] = "$columnName: $columnType";
+        }
+        return $columns;
+    }
+
+    protected function extractForeignKeysFromColumns($columns)
+    {
+        $foreignKeys = [];
+        foreach ($columns as $column) {
+            if (strpos($column, 'foreign') !== false) {
+                $columnName = explode(':', $column)[0];
+                $foreignKeys[] = $columnName;
+            }
+        }
+        return $foreignKeys;
+    }
+
+
+
+    /**
+     * build UML  from objects of table 
+     *
+     * @param array $tables
+     * @return string
+     */
+    protected function buildUmlFromTables($tables)
+    {
+        $umlContent = '@startuml' . PHP_EOL;
+        foreach ($tables as $table) {
+            $umlContent .= "class {$table->name} {" . PHP_EOL;
+            foreach ($table->columns as $column) {
+                $umlContent .= "    $column" . PHP_EOL;
+            }
+            // foreach ($table->foreignKeys as $foreignKey) {
+            //     $umlContent .= "    $foreignKey" . PHP_EOL;
+            // }
+            $umlContent .= '}' . PHP_EOL;
+            foreach ($table->foreignKeys as $foreignKey) {
+                //relationship
+                $umlContent .= $table->name."\"*\"--\"1\""  . ucfirst(preg_replace('/_id$/', 's', $foreignKey)) . PHP_EOL;
+            }
+        }
+        $umlContent .= '@enduml' . PHP_EOL;
+        return $umlContent;
+    }
+}
+
+class Table
+{
+    public $name;
+    public $columns = [];
+    public $foreignKeys = [];
+}

--- a/src/PlantServiceProvider.php
+++ b/src/PlantServiceProvider.php
@@ -29,6 +29,7 @@ class PlantServiceProvider extends ServiceProvider
                 Commands\PlantMigrations::class,
                 Commands\PlantModels::class,
                 Commands\PlantControllers::class,
+                Commands\GenerateUmlFromMigrations::class,
             ]);
         }
     }


### PR DESCRIPTION
This will search for all migrations in your Laravel project, analyze the table and column definitions, and generate a file named database_diagram.puml in the root of your project.